### PR TITLE
Add React Native camera app scaffold

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,14 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.advancedcameraapp">
+  <uses-permission android:name="android.permission.CAMERA" />
+  <uses-permission android:name="android.permission.RECORD_AUDIO" />
+  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+  <application
+    android:allowBackup="true"
+    android:label="AdvancedCameraApp"
+    android:supportsRtl="true">
+    <activity
+      android:name="com.facebook.react.devsupport.DevSettingsActivity"/>
+  </application>
+</manifest>

--- a/app.json
+++ b/app.json
@@ -1,0 +1,4 @@
+{
+  "name": "AdvancedCameraApp",
+  "displayName": "AdvancedCameraApp"
+}

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  presets: ['module:metro-react-native-babel-preset'],
+  plugins: ['react-native-reanimated/plugin'],
+};

--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+import { AppRegistry } from 'react-native';
+import App from './src/App';
+import { name as appName } from './app.json';
+
+AppRegistry.registerComponent(appName, () => App);

--- a/ios/CameraApp/Info.plist
+++ b/ios/CameraApp/Info.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDisplayName</key>
+  <string>AdvancedCameraApp</string>
+  <key>NSCameraUsageDescription</key>
+  <string>This app requires access to the camera.</string>
+  <key>NSMicrophoneUsageDescription</key>
+  <string>This app requires access to the microphone.</string>
+  <key>NSPhotoLibraryAddUsageDescription</key>
+  <string>Permission to save photos.</string>
+</dict>
+</plist>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "AdvancedCameraApp",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "react-native start"
+  },
+  "dependencies": {
+    "react": "18.2.0",
+    "react-native": "0.73.4",
+    "react-native-vision-camera": "^2.15.4",
+    "react-native-permissions": "^3.8.0",
+    "react-native-paper": "^5.0.0",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/bottom-tabs": "^6.5.8",
+    "react-native-reanimated": "^3.1.0",
+    "react-native-gesture-handler": "^2.12.0",
+    "react-native-fs": "^2.20.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.14",
+    "@types/react-native": "^0.72.9",
+    "typescript": "^5.3.3"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import Navigation from './navigation';
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Navigation />
+    </NavigationContainer>
+  );
+}

--- a/src/components/CameraControls.tsx
+++ b/src/components/CameraControls.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { View } from 'react-native';
+import { Switch, Text, Slider } from 'react-native-paper';
+
+interface Props {
+  iso: number;
+  setIso: (v: number) => void;
+  isoAuto: boolean;
+  setIsoAuto: (v: boolean) => void;
+  shutter: number;
+  setShutter: (v: number) => void;
+  focus: number;
+  setFocus: (v: number) => void;
+}
+
+export default function CameraControls({
+  iso,
+  setIso,
+  isoAuto,
+  setIsoAuto,
+  shutter,
+  setShutter,
+  focus,
+  setFocus,
+}: Props) {
+  return (
+    <View>
+      <Text>ISO {isoAuto ? '(Auto)' : iso}</Text>
+      <Switch value={isoAuto} onValueChange={setIsoAuto} />
+      {!isoAuto && <Slider value={iso} onValueChange={setIso} minimumValue={100} maximumValue={1600} />}
+      <Text>Shutter {shutter.toFixed(0)} ms</Text>
+      <Slider value={shutter} onValueChange={setShutter} minimumValue={1} maximumValue={1000} />
+      <Text>Focus {focus.toFixed(2)}</Text>
+      <Slider value={focus} onValueChange={setFocus} minimumValue={0} maximumValue={1} />
+    </View>
+  );
+}

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import CameraScreen from '../screens/CameraScreen';
+import GalleryScreen from '../screens/GalleryScreen';
+import SettingsScreen from '../screens/SettingsScreen';
+import { Provider as PaperProvider } from 'react-native-paper';
+
+const Tab = createBottomTabNavigator();
+
+export default function Navigation() {
+  return (
+    <PaperProvider>
+      <Tab.Navigator screenOptions={{ headerShown: false }}>
+        <Tab.Screen name="Camera" component={CameraScreen} />
+        <Tab.Screen name="Gallery" component={GalleryScreen} />
+        <Tab.Screen name="Settings" component={SettingsScreen} />
+      </Tab.Navigator>
+    </PaperProvider>
+  );
+}

--- a/src/screens/CameraScreen.tsx
+++ b/src/screens/CameraScreen.tsx
@@ -1,0 +1,107 @@
+import React, { useEffect, useState, useRef } from 'react';
+import { View, StyleSheet, TouchableOpacity } from 'react-native';
+import { Camera, useCameraDevices } from 'react-native-vision-camera';
+import { IconButton } from 'react-native-paper';
+import CameraControls from '../components/CameraControls';
+import { ensureDir, generateFilename } from '../utils/fileStorage';
+import RNFS from 'react-native-fs';
+import { check, request, PERMISSIONS, RESULTS } from 'react-native-permissions';
+
+export default function CameraScreen() {
+  const camera = useRef<Camera>(null);
+  const devices = useCameraDevices();
+  const device = devices.back;
+
+  const [isRecording, setIsRecording] = useState(false);
+  const [flash, setFlash] = useState<'off' | 'on' | 'auto'>('off');
+  const [isoAuto, setIsoAuto] = useState(true);
+  const [iso, setIso] = useState(100);
+  const [shutter, setShutter] = useState(1);
+  const [focus, setFocus] = useState(0);
+
+  useEffect(() => {
+    (async () => {
+      const cam = await Camera.requestCameraPermission();
+      const mic = await Camera.requestMicrophonePermission();
+      await ensureDir();
+    })();
+  }, []);
+
+  const takePhoto = async () => {
+    if (!camera.current) return;
+    const photo = await camera.current.takePhoto({ flash });
+    const dest = generateFilename('jpg');
+    await RNFS.moveFile(photo.path, dest);
+  };
+
+  const startRecording = async () => {
+    if (!camera.current) return;
+    setIsRecording(true);
+    const dest = generateFilename('mp4');
+    await camera.current.startRecording({
+      flash,
+      onRecordingFinished: async (video) => {
+        await RNFS.moveFile(video.path, dest);
+        setIsRecording(false);
+      },
+      onRecordingError: (err) => console.warn(err),
+    });
+  };
+
+  const stopRecording = () => {
+    camera.current?.stopRecording();
+  };
+
+  if (!device) return null;
+  return (
+    <View style={styles.container}>
+      <Camera
+        ref={camera}
+        style={StyleSheet.absoluteFill}
+        device={device}
+        isActive
+        photo
+        video
+        flash={flash}
+        iso={!isoAuto ? iso : undefined}
+        exposure={!isoAuto ? undefined : shutter}
+        focusDepth={focus}
+      />
+      <View style={styles.controls}>
+        <IconButton
+          icon={flash === 'off' ? 'flash-off' : flash === 'on' ? 'flash' : 'flash-auto'}
+          onPress={() =>
+            setFlash(flash === 'off' ? 'on' : flash === 'on' ? 'auto' : 'off')
+          }
+        />
+        <TouchableOpacity onPress={isRecording ? stopRecording : startRecording}>
+          <IconButton icon={isRecording ? 'stop' : 'record-rec'} />
+        </TouchableOpacity>
+        <IconButton icon="camera" onPress={takePhoto} />
+      </View>
+      <CameraControls
+        iso={iso}
+        setIso={setIso}
+        isoAuto={isoAuto}
+        setIsoAuto={setIsoAuto}
+        shutter={shutter}
+        setShutter={setShutter}
+        focus={focus}
+        setFocus={setFocus}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#000',
+  },
+  controls: {
+    position: 'absolute',
+    bottom: 20,
+    alignSelf: 'center',
+    flexDirection: 'row',
+  },
+});

--- a/src/screens/GalleryScreen.tsx
+++ b/src/screens/GalleryScreen.tsx
@@ -1,0 +1,43 @@
+import React, { useEffect, useState } from 'react';
+import { View, FlatList, Image, TouchableOpacity, Modal } from 'react-native';
+import RNFS from 'react-native-fs';
+import { ensureDir } from '../utils/fileStorage';
+
+export default function GalleryScreen() {
+  const [files, setFiles] = useState<string[]>([]);
+  const [selected, setSelected] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      await ensureDir();
+      const dir = `${RNFS.ExternalDirectoryPath}/AdvancedCameraApp`;
+      const list = await RNFS.readDir(dir);
+      setFiles(list.map(f => `file://${f.path}`));
+    })();
+  }, []);
+
+  return (
+    <View style={{ flex: 1 }}>
+      <FlatList
+        data={files}
+        numColumns={3}
+        keyExtractor={(item) => item}
+        renderItem={({ item }) => (
+          <TouchableOpacity onPress={() => setSelected(item)}>
+            <Image source={{ uri: item }} style={{ width: 100, height: 100 }} />
+          </TouchableOpacity>
+        )}
+      />
+      <Modal visible={!!selected} onRequestClose={() => setSelected(null)}>
+        <TouchableOpacity style={{ flex: 1 }} onPress={() => setSelected(null)}>
+          {selected && (
+            <Image
+              source={{ uri: selected }}
+              style={{ flex: 1, resizeMode: 'contain' }}
+            />
+          )}
+        </TouchableOpacity>
+      </Modal>
+    </View>
+  );
+}

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function SettingsScreen() {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>Settings</Text>
+    </View>
+  );
+}

--- a/src/utils/fileStorage.ts
+++ b/src/utils/fileStorage.ts
@@ -1,0 +1,15 @@
+import RNFS from 'react-native-fs';
+
+const DIR = `${RNFS.ExternalDirectoryPath}/AdvancedCameraApp`;
+
+export async function ensureDir() {
+  const exists = await RNFS.exists(DIR);
+  if (!exists) {
+    await RNFS.mkdir(DIR);
+  }
+}
+
+export function generateFilename(ext: string) {
+  const ts = new Date().toISOString().replace(/[:.]/g, '-');
+  return `${DIR}/${ts}.${ext}`;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "commonjs",
+    "strict": true,
+    "jsx": "react",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "allowSyntheticDefaultImports": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "moduleResolution": "node",
+    "types": ["react-native"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.tsx"]
+}


### PR DESCRIPTION
## Summary
- initialize React Native TS project skeleton
- add navigation with bottom tabs
- implement camera screen with vision-camera and controls
- implement gallery screen to view saved media
- add placeholder settings screen
- add file storage utilities
- configure Android and iOS permissions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853ad9b6d088332b119462eb4f3994c